### PR TITLE
사용할 기본 폰트 Util에 추가

### DIFF
--- a/Tikkle/Tikkle.xcodeproj/project.pbxproj
+++ b/Tikkle/Tikkle.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		18C8C9362A8B6C45008E4C92 /* DummyData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C8C9352A8B6C45008E4C92 /* DummyData.swift */; };
 		18C8C9382A8B6C65008E4C92 /* DummyCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C8C9372A8B6C65008E4C92 /* DummyCreator.swift */; };
 		18C8C93A2A8B6C81008E4C92 /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C8C9392A8B6C81008E4C92 /* UIColor.swift */; };
+		18FEC5B42A8C6BF300A804DD /* UIFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18FEC5B32A8C6BF300A804DD /* UIFont.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -54,6 +55,7 @@
 		18C8C9352A8B6C45008E4C92 /* DummyData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyData.swift; sourceTree = "<group>"; };
 		18C8C9372A8B6C65008E4C92 /* DummyCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyCreator.swift; sourceTree = "<group>"; };
 		18C8C9392A8B6C81008E4C92 /* UIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColor.swift; sourceTree = "<group>"; };
+		18FEC5B32A8C6BF300A804DD /* UIFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIFont.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -172,6 +174,7 @@
 			children = (
 				18C8C9372A8B6C65008E4C92 /* DummyCreator.swift */,
 				18C8C9392A8B6C81008E4C92 /* UIColor.swift */,
+				18FEC5B32A8C6BF300A804DD /* UIFont.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -262,6 +265,7 @@
 				18C8C9262A8B63B1008E4C92 /* CreateTikklePageViewController.swift in Sources */,
 				18C8C92E2A8B63D9008E4C92 /* FeedPageViewController.swift in Sources */,
 				18C8C93A2A8B6C81008E4C92 /* UIColor.swift in Sources */,
+				18FEC5B42A8C6BF300A804DD /* UIFont.swift in Sources */,
 				18C8C9382A8B6C65008E4C92 /* DummyCreator.swift in Sources */,
 				18C8C9362A8B6C45008E4C92 /* DummyData.swift in Sources */,
 				18C8C9342A8B6C24008E4C92 /* Stamp.swift in Sources */,

--- a/Tikkle/Tikkle/Util/UIFont.swift
+++ b/Tikkle/Tikkle/Util/UIFont.swift
@@ -1,0 +1,22 @@
+//
+//  UIFont.swift
+//  Tikkle
+//
+//  Created by 김도현 on 2023/08/16.
+//
+
+import Foundation
+import UIKit
+
+extension UIFont {
+    static let display = systemFont(ofSize: 30, weight: .bold)
+    static let diplay2 = systemFont(ofSize: 25, weight: .bold)
+    static let display3Bold = systemFont(ofSize: 22, weight: .bold)
+    static let display3Regular = systemFont(ofSize: 22, weight: .regular)
+    
+    static let body1SemiBold = systemFont(ofSize: 18, weight: .semibold)
+    static let body1Regular = systemFont(ofSize: 18, weight: .regular)
+    static let body2Bold = systemFont(ofSize: 14, weight: .bold)
+    static let body2Medium = systemFont(ofSize: 14, weight: .medium)
+    static let body3Medium = systemFont(ofSize: 13, weight: .medium)
+}


### PR DESCRIPTION
우리가 사용할 폰트들을 Util/UIFont에 extension 하여서 정리해놓았습니다.
사용할 폰트는 [Tikkle 피그마](https://www.figma.com/file/61fVXAPujYElpfcwy4IzYK/T!kkle-(Copy)?type=design&node-id=135-673&mode=design&t=kEY0p7HsBEMS5is5-0) 사이트에 각 폰트들이 적용되어 있어 디자인 보시고 폰트를 적용하시면 됩니다.

## 폰트 사이즈
<img width="474" alt="스크린샷 2023-08-16 오후 12 08 30" src="https://github.com/three523/Tikkle/assets/71269216/e7444100-319c-46a8-b277-a624761a12a2">
