### PR TITLE
fix/도전하기 이전에는 TikklePage에서 날짜라벨 보이지 않도록 수정

### DIFF
--- a/Tikkle/Tikkle/TikklePageViewController.swift
+++ b/Tikkle/Tikkle/TikklePageViewController.swift
@@ -70,23 +70,36 @@ class TikklePageViewController: UIViewController {
     
     //MARK: - TikklePage Image, Title, Info, 날짜 세팅 가져오기
     func uiSet() {
-        updateDaysLabel()
-        updateDateLabel()
+        guard let unwrappedTikkle = tikkle else { return }
         
-        guard let tikkle else { return }
-        TikklePageImage.image = tikkle.image
+        updateLabelsBasedOnChallenge(isChallenge: tikkleList.getTikkle(where: unwrappedTikkle.id) != nil)
+        
+        TikklePageImage.image = unwrappedTikkle.image
         TikklePageImage.contentMode = .scaleAspectFill
         TikklePageImage.layer.cornerRadius = TikklePageImage.frame.height / 2
-        TikklePageTitle.text = tikkle.title
-        TikklePageInfo.text = tikkle.description
+        TikklePageTitle.text = unwrappedTikkle.title
+        TikklePageInfo.text = unwrappedTikkle.description
         
-        
-        challengeUpdate(isChallenge: tikkleList.getTikkle(where: tikkle.id) != nil)
+        challengeUpdate(isChallenge: tikkleList.getTikkle(where: unwrappedTikkle.id) != nil)
+    }
+    
+    
+    func updateLabelsBasedOnChallenge(isChallenge: Bool) {
+        if isChallenge {
+            updateDateLabel()
+            updateDaysLabel()
+            TikklePageDateLabel.isHidden = false
+            TikklePageDaysLabel.isHidden = false
+        } else {
+            TikklePageDateLabel.isHidden = true
+            TikklePageDaysLabel.isHidden = true
+        }
     }
     
     
     //날짜 출력 함수
     func updateDateLabel() {
+        
         guard let tikkle = tikkle else { return }
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yy.MM.dd ~ 현재"


### PR DESCRIPTION
<!--
코드를 변경한 경우 어떤 부분을 변경했는지 구체적으로 작성
스크린샷의 경우 UI의 변경이 있었거나 UI를 수정한 경우 작성하고 아니면 비워두기
-->

## 작업내용 (이미지)
도전하기 버튼 누르기 이전에는 하단의 이미지와 같이 날짜 라벨이 보이지 않습니다. 

![simulator_screenshot_EB4E8DF0-7B48-4804-A558-E55E2C7139E6](https://github.com/three523/Tikkle/assets/85066307/1a0cd32c-c069-43fd-b646-ee4d2892645d)


도전중을 누르면 하단의 이미지와 같이 날짜 라벨이 보입니다. 
![simulator_screenshot_CAD3AB98-9E47-4C48-B283-3C74CDCDFDDD](https://github.com/three523/Tikkle/assets/85066307/3099c483-0a33-489e-bf4c-71fc3f38c09c)

