### PR TITLE
feat/FeedPage UI 수정

### DIFF
--- a/Tikkle/Tikkle/FeedPage/FeedPage.storyboard
+++ b/Tikkle/Tikkle/FeedPage/FeedPage.storyboard
@@ -5,7 +5,6 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -137,11 +136,15 @@
                                     <rect key="frame" x="0.0" y="0.0" width="353" height="130"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalCentering" alignment="top" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="4KQ-Ey-y6M">
-                                            <rect key="frame" x="8" y="8" width="337" height="114"/>
+                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalCentering" alignment="top" spacing="-10" translatesAutoresizingMaskIntoConstraints="NO" id="4KQ-Ey-y6M">
+                                            <rect key="frame" x="0.0" y="22" width="345" height="90"/>
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OBs-2P-pQ8">
-                                                    <rect key="frame" x="0.0" y="0.0" width="48.666666666666664" height="27.333333333333332"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="55" height="30"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="55" id="PfO-Fc-eyK"/>
+                                                        <constraint firstAttribute="height" constant="30" id="oep-gO-8oZ"/>
+                                                    </constraints>
                                                     <state key="normal" title="Button"/>
                                                     <buttonConfiguration key="configuration" style="plain" title="HOT">
                                                         <fontDescription key="titleFontDescription" type="boldSystem" pointSize="11"/>
@@ -149,18 +152,19 @@
                                                     </buttonConfiguration>
                                                 </button>
                                                 <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="bottom" translatesAutoresizingMaskIntoConstraints="NO" id="kuK-of-QhF">
-                                                    <rect key="frame" x="0.0" y="42.333333333333336" width="337" height="71.666666666666657"/>
+                                                    <rect key="frame" x="0.0" y="30" width="345" height="60"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XeA-bl-dc7">
-                                                            <rect key="frame" x="0.0" y="0.0" width="168.66666666666666" height="71.666666666666671"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="140.33333333333334" height="60"/>
                                                             <string key="text">요즘 핫한 
 티끌 도전 모음</string>
-                                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
+                                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="25"/>
                                                             <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                             <nil key="highlightedColor"/>
+                                                            <size key="shadowOffset" width="0.0" height="0.0"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="더보기" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qew-dd-IOv">
-                                                            <rect key="frame" x="303" y="55.999999999999993" width="34" height="15.666666666666664"/>
+                                                            <rect key="frame" x="311" y="44.333333333333329" width="34" height="15.666666666666664"/>
                                                             <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
                                                             <color key="textColor" red="0.67843137249999996" green="0.67843137249999996" blue="0.67843137249999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <nil key="highlightedColor"/>
@@ -175,9 +179,9 @@
                                         </stackView>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstItem="4KQ-Ey-y6M" firstAttribute="top" secondItem="3MG-uo-Ror" secondAttribute="topMargin" id="1tZ-Mv-f5j"/>
-                                        <constraint firstItem="4KQ-Ey-y6M" firstAttribute="leading" secondItem="3MG-uo-Ror" secondAttribute="leadingMargin" id="478-fk-sAj"/>
-                                        <constraint firstAttribute="bottomMargin" secondItem="4KQ-Ey-y6M" secondAttribute="bottom" id="XTn-fb-mhp"/>
+                                        <constraint firstItem="4KQ-Ey-y6M" firstAttribute="top" secondItem="3MG-uo-Ror" secondAttribute="topMargin" constant="14" id="1tZ-Mv-f5j"/>
+                                        <constraint firstItem="4KQ-Ey-y6M" firstAttribute="leading" secondItem="3MG-uo-Ror" secondAttribute="leadingMargin" constant="-8" id="478-fk-sAj"/>
+                                        <constraint firstAttribute="bottomMargin" secondItem="4KQ-Ey-y6M" secondAttribute="bottom" constant="10" id="XTn-fb-mhp"/>
                                         <constraint firstAttribute="trailingMargin" secondItem="4KQ-Ey-y6M" secondAttribute="trailing" id="sHT-X9-cBQ"/>
                                     </constraints>
                                     <connections>

--- a/Tikkle/Tikkle/FeedPage/OtherTikkleCollectionReusableView.swift
+++ b/Tikkle/Tikkle/FeedPage/OtherTikkleCollectionReusableView.swift
@@ -15,6 +15,7 @@ class OtherTikkleCollectionReusableView: UICollectionReusableView {
         st.axis = .vertical
         st.alignment = .leading
         st.distribution = .fillProportionally
+        st.spacing = -16
         return st
     }()
     let otherTikkleTitleLabel: UILabel = {
@@ -26,9 +27,9 @@ class OtherTikkleCollectionReusableView: UICollectionReusableView {
     }()
     let otherSubTitleLabel: UILabel = {
         let lb = UILabel()
-        lb.text = "다른 분들의 도전을 둘러보세요"
-        lb.font = .systemFont(ofSize: 14, weight: .bold)
-        lb.textColor = UIColor(hexCode: "D9D9D9")
+        lb.text = "다른 분들의 도전을 둘러보세요!"
+        lb.font = .systemFont(ofSize: 14, weight: .heavy)
+        lb.textColor = UIColor.subTitleColor
         return lb
     }()
     override init(frame: CGRect) {


### PR DESCRIPTION
<!--
코드를 변경한 경우 어떤 부분을 변경했는지 구체적으로 작성
스크린샷의 경우 UI의 변경이 있었거나 UI를 수정한 경우 작성하고 아니면 비워두기
-->
## 작업내용
feat/FeedPage UI 수정
폰트 크기와 요소간의 여백 조정하였습니다.
윗부분의 '요즘 핫한 티끌 도전 모음'의 이미지 부분은 어떻게 수정해야할 지 몰라서 그대로 두었습니다 ! 

## 작업내용 (이미지)
![simulator_screenshot_297E20DF-5227-447A-8CC6-A3F22B5145C9](https://github.com/three523/Tikkle/assets/85066307/4b2149b7-9468-4738-a866-2806270540b8)
