### PR TITLE
feat/TikklePage 날짜 바로 업데이트 되도록, '도전하기'버튼 누르기 이전 날짜 라벨 기본 값 세팅

### DIFF
--- a/Tikkle/Tikkle/TikklePageViewController.swift
+++ b/Tikkle/Tikkle/TikklePageViewController.swift
@@ -91,8 +91,8 @@ class TikklePageViewController: UIViewController {
             TikklePageDateLabel.isHidden = false
             TikklePageDaysLabel.isHidden = false
         } else {
-            TikklePageDateLabel.isHidden = true
-            TikklePageDaysLabel.isHidden = true
+            TikklePageDateLabel.text = "00.00.00"
+            TikklePageDaysLabel.text = "도전중이 아닙니다"
         }
     }
     
@@ -150,6 +150,8 @@ class TikklePageViewController: UIViewController {
     }
     @IBAction func callengeStart(_ sender: Any) {
         guard let tikkle else { return }
+        updateDateLabel()
+        updateDaysLabel()
         tikkleList.addTikkle(tikkle)
         challengeUpdate(isChallenge: true)
     }


### PR DESCRIPTION
<!--
코드를 변경한 경우 어떤 부분을 변경했는지 구체적으로 작성
스크린샷의 경우 UI의 변경이 있었거나 UI를 수정한 경우 작성하고 아니면 비워두기
-->
## 작업내용
TikklePage 날짜 바로 업데이트 되도록, '도전하기'버튼 누르기 이전 날짜 라벨 기본 값 세팅하였습니다. 

## 작업내용 (이미지)
https://github.com/three523/Tikkle/assets/85066307/7d5f693e-e290-48cd-b163-66d18ee49507




