### PR TITLE
feat/FeedPage 더미리스트 데이터 불러오는 로직만 구현

### DIFF
--- a/Tikkle/Tikkle/FeedPage/FeedPageViewController.swift
+++ b/Tikkle/Tikkle/FeedPage/FeedPageViewController.swift
@@ -12,7 +12,10 @@ protocol ViewControllerPushDelegate: AnyObject {
 }
 
 class FeedPageViewController: UIViewController {
-        
+    private var combinedList: [Tikkle] {
+           return tikkleManage.publicTikkleList() + DummyList.dummylist //✅합치고
+       }
+    
     @IBOutlet weak var feedCollectionView: UICollectionView!
     private var tikkleManage: TikkleListManager = TikkleListManager()
     
@@ -62,37 +65,57 @@ extension FeedPageViewController: UICollectionViewDelegate, UICollectionViewData
     func numberOfSections(in collectionView: UICollectionView) -> Int {
         return 2
     }
+    
+    //✅
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return section == 0 ? 1 : tikkleManage.publicTikkleList().count
+        return section == 0 ? 1 : combinedList.count
     }
     
+    //✅ 필수 메서드 : 각 셀의 내용을 구성해줘
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        
         if indexPath.section == 0 {
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HorizontalCollectionViewCell.identifier, for: indexPath) as? HorizontalCollectionViewCell else { return UICollectionViewCell() }
-            cell.layer.cornerRadius = 6
-            cell.layer.masksToBounds = true
-            cell.delegate = self
-            return cell
-        } else if indexPath.section == 1 {
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: OtherTikkleCollectionViewCell.identifier, for: indexPath) as? OtherTikkleCollectionViewCell else { return UICollectionViewCell(frame: .zero) }
-            cell.layer.cornerRadius = 6
-            cell.layer.masksToBounds = true
-            cell.tikkle = tikkleManage.publicTikkle(at: indexPath.row)
-            return cell
+               guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HorizontalCollectionViewCell.identifier, for: indexPath) as? HorizontalCollectionViewCell else { return UICollectionViewCell() }
+               cell.layer.cornerRadius = 6
+               cell.layer.masksToBounds = true
+               cell.delegate = self
+               return cell
+            
+            
+           } else if indexPath.section == 1 {
+               guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: OtherTikkleCollectionViewCell.identifier, for: indexPath) as? OtherTikkleCollectionViewCell else { return UICollectionViewCell(frame: .zero) }
+               cell.layer.cornerRadius = 6
+               cell.layer.masksToBounds = true
+
+               cell.tikkle = combinedList[indexPath.row]
+               
+               return cell
+           }
+           return UICollectionViewCell()
         }
-        return UICollectionViewCell()
-    }
     
+    //✅특정 셀 탭했을 때 실행 돼
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if indexPath.section == 1 {
-            let storyboard = UIStoryboard(name: "TikklePage", bundle: nil)
-            guard let vc = storyboard.instantiateViewController(withIdentifier: "TikklePageViewController") as? TikklePageViewController else { return }
-            //MARK: - 공개한 리스트만 넘기는 것
-//            vc.tikkle = tikkleManage.publicTikkleList()[indexPath.row]
-            vc.tikkle = DummyList.dummylist[indexPath.item]
-            navigationController?.pushViewController(vc, animated: true)
+                //UIStoryboard 객체를 생성하여 TikklePage라는 이름의 스토리보드를 로드
+                let storyboard = UIStoryboard(name: "TikklePage", bundle: nil)
+                //뷰컨트롤러 인스턴스 생성
+                guard let vc = storyboard.instantiateViewController(withIdentifier: "TikklePageViewController") as? TikklePageViewController else { return }
+                //데이터 할당. 여기서 합친 리스트를 줘.
+                vc.tikkle = combinedList[indexPath.row]
+
+                navigationController?.pushViewController(vc, animated: true)
+            }
         }
-    }
+            
+            
+//
+//            //MARK: - 공개한 리스트만 넘기는 것
+////            vc.tikkle = tikkleManage.publicTikkleList()[indexPath.row]
+//            vc.tikkle = DummyList.dummylist[indexPath.item]
+//            navigationController?.pushViewController(vc, animated: true)
+//        }
+//    }
     
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         switch kind {

--- a/Tikkle/Tikkle/DummyData.swift
+++ b/Tikkle/Tikkle/DummyData.swift
@@ -102,10 +102,19 @@ let tripOverseasTikkle: Tikkle = Tikkle(image: UIImage(named: "plane"), title: "
 //
 struct DummyList {
     //티끌 더미데이터
-    static var dummylist: [Tikkle] = [coding]
+    static var dummylist: [Tikkle] = [coding, coding2]
 }
 
 let coding: Tikkle = Tikkle(image: UIImage(named: "coding"), title: "1일 1 커밋하기", description: "하루에 한번씩 커밋해보아요", isPrivate: false, isSharedProject: true, stampList:  [
+    Stamp(title: "1일", isCompletion: false),
+    Stamp(title: "2일", isCompletion: false),
+    Stamp(title: "3일", isCompletion: false),
+    Stamp(title: "4일", isCompletion: false),
+    Stamp(title: "5일", isCompletion: false)
+])
+
+
+let coding2: Tikkle = Tikkle(image: UIImage(named: "coding"), title: "1일 1 커밋하기2222", description: "하루에 한번씩 커밋해보아요", isPrivate: false, isSharedProject: true, stampList:  [
     Stamp(title: "1일", isCompletion: false),
     Stamp(title: "2일", isCompletion: false),
     Stamp(title: "3일", isCompletion: false),


### PR DESCRIPTION
<!--
코드를 변경한 경우 어떤 부분을 변경했는지 구체적으로 작성
스크린샷의 경우 UI의 변경이 있었거나 UI를 수정한 경우 작성하고 아니면 비워두기
-->
## 작업내용
더미데이터 불러와서 피드페이지에 보여주는 로직 구현 완료했습니다. 
새로 만들어지는 데이터와  더미데이터를 합친 combinedList 를 만들어서 테이블뷰와 연결하였습니다. 


## 작업내용 (이미지)

![simulator_screenshot_C7CE4E5E-2F06-4B6E-BF21-978427B3C83B](https://github.com/three523/Tikkle/assets/85066307/b7f5b1a6-5f68-45ea-a5ca-c101d209673c)


