### PR TITLE
fix/ProgressBarAnimation 탭바 이동후에도 애니메이션 기능 구현

### DIFF
--- a/Tikkle/Tikkle/FeedPage/FeedPageViewController.swift
+++ b/Tikkle/Tikkle/FeedPage/FeedPageViewController.swift
@@ -100,7 +100,6 @@ extension FeedPageViewController: UICollectionViewDelegate, UICollectionViewData
             
             cell.tikkle = combinedList[indexPath.row]
             
-
             return cell
         }
         return UICollectionViewCell()

--- a/Tikkle/Tikkle/FeedPage/OtherTikkleCollectionViewCell.swift
+++ b/Tikkle/Tikkle/FeedPage/OtherTikkleCollectionViewCell.swift
@@ -58,6 +58,7 @@ class OtherTikkleCollectionViewCell: UICollectionViewCell {
         view.layer.cornerRadius = 6
         return view
     }()
+    var progressBarAnimationLayer: CALayer? = nil
     
     let backgroundImageView = UIImageView(image: UIImage(named: "profileImg"))
     var tikkle: Tikkle? = nil {
@@ -124,11 +125,18 @@ class OtherTikkleCollectionViewCell: UICollectionViewCell {
         guard let tikkle else { return }
         
         layoutIfNeeded()
+        
+        if let progressBarAnimationLayer {
+            progressBarAnimationLayer.removeFromSuperlayer()
+        }
+                
         let notCompleteCount = tikkle.stampList.count - tikkle.stampList.filter { $0.isCompletion }.count
         let completeRate: Double = Double(notCompleteCount) / Double(tikkle.stampList.count)
         let fillLayer = CALayer()
         fillLayer.frame = CGRect(x: 0, y: progressBar.bounds.height * completeRate, width: progressBar.bounds.width, height: progressBar.bounds.height)
         fillLayer.backgroundColor = UIColor.mainColor.cgColor
+        
+        progressBarAnimationLayer = fillLayer
         
         let animation = CABasicAnimation(keyPath: "position.y")
         animation.fromValue = progressBar.bounds.height + (progressBar.bounds.height / 2)
@@ -138,4 +146,5 @@ class OtherTikkleCollectionViewCell: UICollectionViewCell {
         
         progressBar.layer.addSublayer(fillLayer)
     }
+    
 }


### PR DESCRIPTION
<!--
코드를 변경한 경우 어떤 부분을 변경했는지 구체적으로 작성
스크린샷의 경우 UI의 변경이 있었거나 UI를 수정한 경우 작성하고 아니면 비워두기
-->
## 작업내용
ProgressBar 탭바 전환시 다시 애니메이션 되도록 변경
## 작업내용 (이미지)
https://github.com/three523/Tikkle/assets/71269216/035099d6-d574-454b-b35d-612247fcb57b

